### PR TITLE
Display actual and expected values for assertion failures

### DIFF
--- a/src/logger.js
+++ b/src/logger.js
@@ -7,6 +7,14 @@ function timeSince (time) {
   return new Date().getTime() - time
 }
 
+function assertionHasDetails (assertion) {
+    return assertion.error && assertion.error.expected && assertion.error.actual;
+}
+
+function sanitise (message) {
+    return message.replace(/'/g, '|\'');
+}
+
 /**
  * Logs TAP test and assertion data to a writable stream.
  * @module logger
@@ -52,10 +60,12 @@ Logger.prototype.startAssertion = function (assertion) {
  */
 Logger.prototype.failAssertion = function () {
   var output = `testFailed name='${this.assertion.name}'`
-  if (this.assertion.error && this.assertion.error.expected && this.assertion.error.actual) {
-        const expected = this.assertion.error.expected.replace(/'/g, '|\'')
-        const actual = this.assertion.error.actual.replace(/'/g, '|\'')
-        output = `${output} type='comparisonFailure' expected='${expected}' actual='${actual}'`
+  const assertion = this.assertion;
+
+  if (assertionHasDetails(assertion)) {
+    const expected = sanitise(assertion.error.expected);
+    const actual = sanitise(assertion.error.actual);
+    output = `${output} type='comparisonFailure' expected='${expected}' actual='${actual}'`
   }
 
   this.output.push(`\n##teamcity[${output}]`)

--- a/src/logger.js
+++ b/src/logger.js
@@ -55,7 +55,7 @@ Logger.prototype.failAssertion = function () {
   if (this.assertion.error && this.assertion.error.expected && this.assertion.error.actual) {
         const expected = this.assertion.error.expected.replace(/'/g, '|\'')
         const actual = this.assertion.error.actual.replace(/'/g, '|\'')
-        output = `${output} expected='${expected}' actual='${actual}'`
+        output = `${output} type='comparisonFailure' expected='${expected}' actual='${actual}'`
   }
 
   this.output.push(`\n##teamcity[${output}]`)

--- a/src/logger.js
+++ b/src/logger.js
@@ -51,9 +51,11 @@ Logger.prototype.startAssertion = function (assertion) {
  * Logs assertion failed
  */
 Logger.prototype.failAssertion = function () {
-  var output = `testFailed name='${this.assertion.name}'`;
-  if (this.assertion.error) {
-        output = `${output} expected='${this.assertion.error.expected}' actual='${this.assertion.error.actual}'`
+  var output = `testFailed name='${this.assertion.name}'`
+  if (this.assertion.error && this.assertion.error.expected && this.assertion.error.actual) {
+        const expected = this.assertion.error.expected.replace(/'/g, '|\'')
+        const actual = this.assertion.error.actual.replace(/'/g, '|\'')
+        output = `${output} expected='${expected}' actual='${actual}'`
   }
 
   this.output.push(`\n##teamcity[${output}]`)

--- a/src/logger.js
+++ b/src/logger.js
@@ -51,7 +51,12 @@ Logger.prototype.startAssertion = function (assertion) {
  * Logs assertion failed
  */
 Logger.prototype.failAssertion = function () {
-  this.output.push(`\n##teamcity[testFailed name='${this.assertion.name}']`)
+  var output = `testFailed name='${this.assertion.name}'`;
+  if (this.assertion.error) {
+        output = `${output} expected='${this.assertion.error.expected}' actual='${this.assertion.error.actual}'`
+  }
+
+  this.output.push(`\n##teamcity[${output}]`)
 }
 
 /**

--- a/test/logger.js
+++ b/test/logger.js
@@ -89,7 +89,7 @@ test('Logger.prototype.failAssertion', (t) => {
   // 13
   t.equal(
     result,
-    `\n##teamcity[testFailed name='${assertion.name}' expected='${assertion.error.expected}' actual='${assertion.error.actual}']`,
+    `\n##teamcity[testFailed name='${assertion.name}' type='comparisonFailure' expected='${assertion.error.expected}' actual='${assertion.error.actual}']`,
     'pushes assertion fail string to output stream')
 })
 
@@ -110,7 +110,7 @@ test('Logger.prototype.failAssertion with quotes', (t) => {
   // 13
   t.equal(
     result,
-    `\n##teamcity[testFailed name='${assertion.name}' expected='expected|' quotes|'' actual='actual |' with |' quotes']`,
+    `\n##teamcity[testFailed name='${assertion.name}' type='comparisonFailure' expected='expected|' quotes|'' actual='actual |' with |' quotes']`,
     'escapes quotes')
 })
 

--- a/test/logger.js
+++ b/test/logger.js
@@ -93,6 +93,27 @@ test('Logger.prototype.failAssertion', (t) => {
     'pushes assertion fail string to output stream')
 })
 
+test('Logger.prototype.failAssertion with quotes', (t) => {
+  t.plan(1)
+  var result = ''
+  const output = through()
+  output.on('data', (d) => { result += d })
+  const logger = Logger(output)
+  const assertion = {
+      name: 'AssertionName',
+      error: {expected: 'expected\' quotes\'', actual: 'actual \' with \' quotes'}
+  }
+  logger.startAssertion(assertion)
+  result = ''
+  logger.failAssertion()
+
+  // 13
+  t.equal(
+    result,
+    `\n##teamcity[testFailed name='${assertion.name}' expected='expected|' quotes|'' actual='actual |' with |' quotes']`,
+    'escapes quotes')
+})
+
 test('Logger.prototype.failAssertion without error', t => {
   t.plan(1)
   var result = ''

--- a/test/logger.js
+++ b/test/logger.js
@@ -78,13 +78,37 @@ test('Logger.prototype.failAssertion', (t) => {
   const output = through()
   output.on('data', (d) => { result += d })
   const logger = Logger(output)
+  const assertion = {
+      name: 'AssertionName',
+      error: {expected: 'expected', actual: 'actual'}
+  }
+  logger.startAssertion(assertion)
+  result = ''
+  logger.failAssertion()
+
+  // 13
+  t.equal(
+    result,
+    `\n##teamcity[testFailed name='${assertion.name}' expected='${assertion.error.expected}' actual='${assertion.error.actual}']`,
+    'pushes assertion fail string to output stream')
+})
+
+test('Logger.prototype.failAssertion without error', t => {
+  t.plan(1)
+  var result = ''
+  const output = through()
+  output.on('data', (d) => { result += d })
+  const logger = Logger(output)
   const assertion = { name: 'AssertionName' }
   logger.startAssertion(assertion)
   result = ''
   logger.failAssertion()
 
   // 13
-  t.equal(result, `\n##teamcity[testFailed name='${assertion.name}']`, 'pushes assertion fail string to output stream')
+  t.equal(
+    result,
+    `\n##teamcity[testFailed name='${assertion.name}']`,
+    'pushes assertion fail string to output stream')
 })
 
 test('Logger.prototype.finishAssertion', (t) => {

--- a/test/tap-teamcity.js
+++ b/test/tap-teamcity.js
@@ -95,7 +95,7 @@ test('tapTeamCity, not ok assertion', (t) => {
   const checkFailed = (data) =>
     t.equal(
       data,
-      '\n##teamcity[testFailed name=\'second assert\']',
+      '\n##teamcity[testFailed name=\'second assert\' expected=\'false\' actual=\'true\']',
       'streams assertion failed message'
     )
   const checkFinish = (data) =>

--- a/test/tap-teamcity.js
+++ b/test/tap-teamcity.js
@@ -95,7 +95,7 @@ test('tapTeamCity, not ok assertion', (t) => {
   const checkFailed = (data) =>
     t.equal(
       data,
-      '\n##teamcity[testFailed name=\'second assert\' expected=\'false\' actual=\'true\']',
+      '\n##teamcity[testFailed name=\'second assert\' type=\'comparisonFailure\' expected=\'false\' actual=\'true\']',
       'streams assertion failed message'
     )
   const checkFinish = (data) =>


### PR DESCRIPTION
TeamCity can display the expected and actual values for a test failure. This change adds these properties into the parsed output, with type='comparisonFailure' which is required to display them.

TeamCity docs for reference: https://confluence.jetbrains.com/display/TCD9/Build+Script+Interaction+with+TeamCity
